### PR TITLE
override_target_metadata прописана при вызовах etlcraft.metadata()

### DIFF
--- a/macros/attr/attr_create_events.sql
+++ b/macros/attr/attr_create_events.sql
@@ -19,7 +19,7 @@
 {# 
     Извлечение метаданных и шагов воронки для формирования событий.
 #}
-{%- set metadata = fromyaml(etlcraft.metadata()) -%}
+{%- set metadata = fromyaml(etlcraft.metadata(override_target_metadata)) -%}
 {%- set funnels = metadata['funnels'] -%}
 {%- set step_name_list = funnels[funnel_name].steps -%}
 {%- set steps = metadata['steps'] -%}

--- a/macros/attr/attr_find_new_period.sql
+++ b/macros/attr/attr_find_new_period.sql
@@ -20,7 +20,7 @@
 {# 
     Извлечение метаданных и шагов воронки для формирования списка шагов и их порядкового номера.
 #}
-{%- set metadata = fromyaml(etlcraft.metadata()) -%}
+{%- set metadata = fromyaml(etlcraft.metadata(override_target_metadata)) -%}
 {%- set funnels = metadata['funnels'] -%}
 {%- set step_name_list = funnels[funnel_name].steps -%}
 {%- set counter = [] -%}

--- a/macros/attr/attr_join_to_attr_prepare_with_qid.sql
+++ b/macros/attr/attr_join_to_attr_prepare_with_qid.sql
@@ -8,7 +8,7 @@
 {# 
     Извлечение метаданных для определения типов моделей и их приоритетов.
 #}
-{%- set metadata = fromyaml(etlcraft.metadata()) -%}
+{%- set metadata = fromyaml(etlcraft.metadata(override_target_metadata)) -%}
 {%- set funnels = metadata['funnels'] -%}
 {%- set attribution_models = metadata['attribution_models'] -%}
 {%- set model_list = funnels[funnel_name].models -%}

--- a/macros/attr/attr_model.sql
+++ b/macros/attr/attr_model.sql
@@ -5,7 +5,7 @@
   limit0=none
   ) -%}
 
-{%- set metadata = fromyaml(etlcraft.metadata()) -%}
+{%- set metadata = fromyaml(etlcraft.metadata(override_target_metadata)) -%}
 {%- set funnels = metadata['funnels'] -%}
 {%- set attribution_models = metadata['attribution_models'] -%}
 {%- set model_list = funnels[funnel_name].models -%}

--- a/macros/full/full.sql
+++ b/macros/full/full.sql
@@ -44,7 +44,7 @@
 {#- ************************************* отбор возможных и существующих таблиц registry ************************************* -#}
 
 {#- создаём список возможных таблиц registry - это нужно для всех пайплайнов -#}
-{%- set metadata = fromyaml(etlcraft.metadata()) -%}
+{%- set metadata = fromyaml(etlcraft.metadata(override_target_metadata)) -%}
 {%- set links_list = [] -%}
 {%- set registry_possible_tables = [] -%}
 {%- set links = metadata['links'] -%}

--- a/macros/graphs/graph_tuples.sql
+++ b/macros/graphs/graph_tuples.sql
@@ -6,7 +6,7 @@
   ) -%}
 
 {# Извлекаем метаданные или используем метаданные по умолчанию #}
-{%- set metadata_dict = fromyaml(override_target_metadata or etlcraft.metadata()) -%}
+{%- set metadata_dict = fromyaml(override_target_metadata or etlcraft.metadata(override_target_metadata)) -%}
 {# Получаем модели склейки из метаданных #}
 {%- set glue_models = metadata_dict['glue_models'] -%}
 

--- a/macros/hash/hash.sql
+++ b/macros/hash/hash.sql
@@ -59,7 +59,7 @@
 {#- ************************************************* работа с metadata *********************************************** -#}
 
 {#- задаём список всех линков -#}
-{%- set metadata = fromyaml(etlcraft.metadata()) -%}
+{%- set metadata = fromyaml(etlcraft.metadata(override_target_metadata)) -%}
 {%- set links = metadata['links'] -%}
 {#- задаём списки, куда будем отбирать линки и сущности -#}
 {%- set links_list = [] -%}


### PR DESCRIPTION
override_target_metadata прописана при вызовах etlcraft.metadata()